### PR TITLE
Implement GitHub API

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
                 </h3>
                 <p>{{ p.description }}</p>
                 <tags v-bind:tags="p.tags"></tags>
-                <iframe class="star-button" v-bind:src="starButton(p)" frameborder="0" scrolling="0" width="160px" height="30px"></iframe>
+                <!-- <iframe class="star-button" v-bind:src="starButton(p)" frameborder="0" scrolling="0" width="160px" height="30px"></iframe> -->
               </div>
             </a>
           </div>
@@ -134,7 +134,7 @@
               <p v-html="p.description"></p>
               <tags v-bind:tags="p.tags"></tags>
             </div>
-            <iframe class="star-button" v-bind:src="starButton(p)" frameborder="0" scrolling="0" width="160px" height="30px"></iframe>
+            <!-- <iframe class="star-button" v-bind:src="starButton(p)" frameborder="0" scrolling="0" width="160px" height="30px"></iframe> -->
           </a>
           <a href="https://medium.com/embarkstudios/a-love-letter-to-blender-e54167c22193" class="button-primary background-grey">Learn More</a>
         </div>

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
                 </h3>
                 <p>{{ p.description }}</p>
                 <tags v-bind:tags="p.tags"></tags>
-                <star-count :project="p" />
+                <github-stats v-bind:project="p" />
               </div>
             </a>
           </div>
@@ -133,7 +133,7 @@
               </h3>
               <p v-html="p.description"></p>
               <tags v-bind:tags="p.tags"></tags>
-              <star-count :project="p" />
+              <github-stats v-bind:project="p" />
             </div>
           </a>
           <a href="https://medium.com/embarkstudios/a-love-letter-to-blender-e54167c22193" class="button-primary background-grey">Learn More</a>

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
                 </h3>
                 <p>{{ p.description }}</p>
                 <tags v-bind:tags="p.tags"></tags>
-                <!-- <iframe class="star-button" v-bind:src="starButton(p)" frameborder="0" scrolling="0" width="160px" height="30px"></iframe> -->
+                <star-count :project="p" />
               </div>
             </a>
           </div>
@@ -133,8 +133,8 @@
               </h3>
               <p v-html="p.description"></p>
               <tags v-bind:tags="p.tags"></tags>
+              <star-count :project="p" />
             </div>
-            <!-- <iframe class="star-button" v-bind:src="starButton(p)" frameborder="0" scrolling="0" width="160px" height="30px"></iframe> -->
           </a>
           <a href="https://medium.com/embarkstudios/a-love-letter-to-blender-e54167c22193" class="button-primary background-grey">Learn More</a>
         </div>

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
           <input id="search-input" type="text" placeholder="Start typing..." v-model="search" ref="search">
           <div class="search-overlay__results">
             <a v-bind:href="repoUrl(p)" class="project" v-for="p in searchedProjects">
-              <div>
+              <div class="project-card">
                 <h3 class="title">
                   <span class="emoji">{{ p.emoji }}</span>
                   {{ p.name }}
@@ -126,7 +126,7 @@
             We have also released an open source add-on featuring some of our day-to-day studio tools.
           </p>
           <a v-bind:href="repoUrl(p)" class="project" v-for="p in projectsWithTag('blender')">
-            <div>
+            <div class="project-card">
               <h3 class="title">
                 <span class="emoji">{{ p.emoji }}</span>
                 {{ p.name }}

--- a/script.js
+++ b/script.js
@@ -8,6 +8,9 @@ const sharedMethods = {
     stargazersUrl(project) {
       return `https://github.com/EmbarkStudios/${project.name}/stargazers`;
     },
+    issuesUrl(project) {
+      return `https://github.com/EmbarkStudios/${project.name}/issues`;
+    },
   },
 };
 
@@ -31,12 +34,36 @@ Vue.component('star-count', {
   mixins: [sharedMethods],
   props: ['project'],
   template: `
-    <div class="github-btn github-stargazers github-btn-large">
+    <div class="github-btn github-stargazers github-btn-large" v-if="project.stargazers_count != undefined">
       <a class="gh-btn" :href="repoUrl(project)" rel="noopener noreferrer" target="_blank">
         <span class="gh-ico" aria-hidden="true"></span>
         <span class="gh-text">Star</span>
       </a>
       <a class="gh-count" :href="stargazersUrl(project)" rel="noopener noreferrer" target="_blank" aria-hidden="true">{{project.stargazers_count}}</a>
+    </div>
+  `,
+});
+
+Vue.component('issues-count', {
+  mixins: [sharedMethods],
+  props: ['project'],
+  template: `
+    <div class="github-btn github-stargazers github-btn-large" v-if="project.open_issues_count != undefined">
+      <a class="gh-btn" :href="repoUrl(project)" rel="noopener noreferrer" target="_blank">
+        <span class="gh-ico" aria-hidden="true"></span>
+        <span class="gh-text">Issues</span>
+      </a>
+      <a class="gh-count" :href="issuesUrl(project)" rel="noopener noreferrer" target="_blank" aria-hidden="true">{{project.open_issues_count}}</a>
+    </div>
+  `,
+});
+
+Vue.component('github-stats', {
+  props: ['project'],
+  template: `
+    <div class="github-buttons-container">
+      <star-count :project="project" />
+      <issues-count :project="project" />
     </div>
   `,
 });
@@ -56,9 +83,8 @@ Vue.component('project-category', {
             </h3>
             <p v-html="p.description"></p>
             <tags v-bind:tags="p.tags"></tags>
-            <star-count :project="p" />
+            <github-stats :project="p" />
           </div>
-          <!-- <iframe class="star-button" v-bind:src="starButton(p)" frameborder="0" scrolling="0" width="160px" height="30px"></iframe> -->
         </a>
       </div>
     </section>

--- a/script.js
+++ b/script.js
@@ -5,10 +5,9 @@ const sharedMethods = {
     repoUrl(project) {
       return `https://github.com/EmbarkStudios/${project.name}`;
     },
-    // starButton(project) {
-    //   return '';
-    //   return `https://ghbtns.com/github-btn.html?user=EmbarkStudios&repo=${project.name}&type=star&count=true&size=large`;
-    // },
+    stargazersUrl(project) {
+      return `https://github.com/EmbarkStudios/${project.name}/stargazers`;
+    },
   },
 };
 
@@ -28,6 +27,20 @@ Vue.component('tags', {
   },
 });
 
+Vue.component('star-count', {
+  mixins: [sharedMethods],
+  props: ['project'],
+  template: `
+    <div class="github-btn github-stargazers github-btn-large">
+      <a class="gh-btn" :href="repoUrl(project)" rel="noopener noreferrer" target="_blank">
+        <span class="gh-ico" aria-hidden="true"></span>
+        <span class="gh-text">Star</span>
+      </a>
+      <a class="gh-count" :href="stargazersUrl(project)" rel="noopener noreferrer" target="_blank" aria-hidden="true">{{project.stargazers_count}}</a>
+    </div>
+  `,
+});
+
 Vue.component('project-category', {
   mixins: [sharedMethods],
   props: ['projects', 'tag'],
@@ -43,6 +56,7 @@ Vue.component('project-category', {
             </h3>
             <p v-html="p.description"></p>
             <tags v-bind:tags="p.tags"></tags>
+            <star-count :project="p" />
           </div>
           <!-- <iframe class="star-button" v-bind:src="starButton(p)" frameborder="0" scrolling="0" width="160px" height="30px"></iframe> -->
         </a>

--- a/script.js
+++ b/script.js
@@ -76,7 +76,7 @@ Vue.component('project-category', {
       <h2 class="category-title">Our <span class="category-tag">{{ tag }}</span> projects</h2>
       <div class="projects-container" v-bind:id="tag">
         <a v-bind:href="repoUrl(p)" class="project" v-for="p in projects">
-          <div>
+          <div class="project-card">
             <h3 class="title">
               <span class="emoji">{{ p.emoji }}</span>
               {{ p.name }}

--- a/style.css
+++ b/style.css
@@ -361,7 +361,9 @@ body > * > * {
 }
 
 /* Licensed under Apache 2.0 https://github.com/mdo/github-buttons/blob/master/LICENSE.md */
+
 /* No modifications were made from the original source */
+
 /* From https://github.com/mdo/github-buttons/blob/master/src/styles.css */
 .github-btn {
   height: 20px;

--- a/style.css
+++ b/style.css
@@ -343,9 +343,17 @@ body > * > * {
   }
 }
 
+.project-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: space-between;
+}
+
 .github-buttons-container {
   display: flex;
   flex-direction: row;
+  text-shadow: none;
 }
 
 .github-buttons-container > div:not(:first-child) {

--- a/style.css
+++ b/style.css
@@ -342,3 +342,134 @@ body > * > * {
     fill: white;
   }
 }
+
+/* From https://github.com/mdo/github-buttons/blob/master/src/styles.css */
+.github-btn {
+  height: 20px;
+  margin-top: 1rem;
+  overflow: hidden;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 14px;
+}
+
+.gh-btn,
+.gh-count,
+.gh-ico {
+  float: left;
+}
+
+.gh-btn,
+.gh-count {
+  padding: 2px 5px 2px 4px;
+  color: #333;
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+  border-radius: 3px;
+}
+
+.gh-btn {
+  background-color: #eee;
+  background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #fcfcfc), to(#eee));
+  background-image: linear-gradient(to bottom, #fcfcfc 0, #eee 100%);
+  background-repeat: no-repeat;
+  border: 1px solid #d5d5d5;
+}
+
+.gh-btn:hover,
+.gh-btn:focus {
+  text-decoration: none;
+  background-color: #ddd;
+  background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #eee), to(#ddd));
+  background-image: linear-gradient(to bottom, #eee 0, #ddd 100%);
+  border-color: #ccc;
+}
+
+.gh-btn:active {
+  background-color: #dcdcdc;
+  background-image: none;
+  border-color: #b5b5b5;
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15);
+}
+
+.gh-ico {
+  width: 14px;
+  height: 14px;
+  margin-right: 4px;
+  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40' viewBox='12 12 40 40'%3e%3cpath fill='%23333' d='M32 13.4c-10.5 0-19 8.5-19 19 0 8.4 5.5 15.5 13 18 1 .2 1.3-.4 1.3-.9v-3.2c-5.3 1.1-6.4-2.6-6.4-2.6-.9-2.1-2.1-2.7-2.1-2.7-1.7-1.2.1-1.1.1-1.1 1.9.1 2.9 2 2.9 2 1.7 2.9 4.5 2.1 5.5 1.6.2-1.2.7-2.1 1.2-2.6-4.2-.5-8.7-2.1-8.7-9.4 0-2.1.7-3.7 2-5.1-.2-.5-.8-2.4.2-5 0 0 1.6-.5 5.2 2 1.5-.4 3.1-.7 4.8-.7 1.6 0 3.3.2 4.7.7 3.6-2.4 5.2-2 5.2-2 1 2.6.4 4.6.2 5 1.2 1.3 2 3 2 5.1 0 7.3-4.5 8.9-8.7 9.4.7.6 1.3 1.7 1.3 3.5v5.2c0 .5.4 1.1 1.3.9 7.5-2.6 13-9.7 13-18.1 0-10.5-8.5-19-19-19z'/%3e%3c/svg%3e") 0 0 / 100% 100% no-repeat;
+}
+
+.gh-count {
+  position: relative;
+  margin-left: 4px;
+  background-color: #fafafa;
+  border: 1px solid #d4d4d4;
+}
+
+.gh-count:hover,
+.gh-count:focus {
+  color: #0366d6;
+}
+
+.gh-count::before,
+.gh-count::after {
+  position: absolute;
+  display: inline-block;
+  width: 0;
+  height: 0;
+  content: "";
+  border-color: transparent;
+  border-style: solid;
+}
+
+.gh-count::before {
+  top: 50%;
+  left: -3px;
+  margin-top: -4px;
+  border-width: 4px 4px 4px 0;
+  border-right-color: #fafafa;
+}
+
+.gh-count::after {
+  top: 50%;
+  left: -4px;
+  z-index: -1;
+  margin-top: -5px;
+  border-width: 5px 5px 5px 0;
+  border-right-color: #d4d4d4;
+}
+
+.github-btn-large {
+  height: 30px;
+}
+
+.github-btn-large .gh-btn,
+.github-btn-large .gh-count {
+  padding: 3px 10px 3px 8px;
+  font-size: 16px;
+  line-height: 22px;
+  border-radius: 4px;
+}
+
+.github-btn-large .gh-ico {
+  width: 20px;
+  height: 20px;
+}
+
+.github-btn-large .gh-count {
+  margin-left: 6px;
+}
+
+.github-btn-large .gh-count::before {
+  left: -5px;
+  margin-top: -6px;
+  border-width: 6px 6px 6px 0;
+}
+
+.github-btn-large .gh-count::after {
+  left: -6px;
+  margin-top: -7px;
+  border-width: 7px 7px 7px 0;
+}

--- a/style.css
+++ b/style.css
@@ -360,6 +360,8 @@ body > * > * {
   margin-left: 0.5rem;
 }
 
+/* Licensed under Apache 2.0 https://github.com/mdo/github-buttons/blob/master/LICENSE.md */
+/* No modifications were made from the original source */
 /* From https://github.com/mdo/github-buttons/blob/master/src/styles.css */
 .github-btn {
   height: 20px;

--- a/style.css
+++ b/style.css
@@ -343,6 +343,15 @@ body > * > * {
   }
 }
 
+.github-buttons-container {
+  display: flex;
+  flex-direction: row;
+}
+
+.github-buttons-container > div:not(:first-child) {
+  margin-left: 0.5rem;
+}
+
 /* From https://github.com/mdo/github-buttons/blob/master/src/styles.css */
 .github-btn {
   height: 20px;


### PR DESCRIPTION
### Checklist

* [X] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [X] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [X] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Implements a request to the Github API to get data for each of the projects. For now it just gets the description, number of stars and issues/prs, although number of forks, watchers, etc., is also there on the response from the API and could be shown.

I replaced the old Star buttons with custom new ones. The old ones had an issue, where each of them makes a request to the API, which after refreshing the page a few times causes the rate limits to be hit, which hides the star buttons on the live version. The new version uses the [Search API](https://developer.github.com/v3/search/#rate-limit), which has much laxer restrictions, and also just makes one request per page load.
The buttons are a copy of [mdo/github-buttons](https://github.com/mdo/github-buttons). The License is Apache 2.0, so I think we need to add something to indicate it, but I'm not sure where. Any ideas?

Some notes about the implementation: 
- The page won't break if the GitHub API is not reachable, it will just not show the Stars/Issues buttons and won't update the descriptions. 
- The API doesn't distinguish between Issues and PRs, so the issues count includes both. 
- I changed how Vue is initialized, now it initializes right after the page finished loading instead of after the `data.json` request finishes. This way users with a slow connection won't see `{{p.emoji}}` while the request finishes loading.

### Related Issues

Fixes #24 
