### PR TITLE
Zola deploy action for publishing to Github pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "*"
   pull_request:
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Build
         uses: shalzz/zola-deploy-action@v0.12.0
         env:
-          BUILD_DIR: build
           BUILD_ONLY: true
           BUILD_FLAGS: --drafts
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -32,6 +31,5 @@ jobs:
       - name: Build and deploy
         uses: shalzz/zola-deploy-action@v0.12.0
         env:
-          BUILD_DIR: build
           PAGES_BRANCH: gh-pages
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
 
   build_and_deploy:
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout main
         uses: actions/checkout@v3.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: Build and deploy
+
+on:
+  push:
+    branches:
+      - main
+      - fix/gh-pages
+    tags:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/fix/gh-pages'
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: build_and_deploy
+        uses: shalzz/zola-deploy-action@v0.14.1
+        env:
+          PAGES_BRANCH: gh-pages
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
 
   build_and_deploy:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref != 'refs/heads/main'
     steps:
       - name: Checkout main
         uses: actions/checkout@v3.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@v3.0.0
       - name: Build
-        uses: shalzz/zola-deploy-action@0.15.3
+        uses: shalzz/zola-deploy-action@v0.12.0
         env:
           BUILD_DIR: docs
           BUILD_ONLY: true
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@v3.0.0
       - name: Build and deploy
-        uses: shalzz/zola-deploy-action@0.15.3
+        uses: shalzz/zola-deploy-action@v0.12.0
         env:
           BUILD_DIR: docs
           PAGES_BRANCH: gh-pages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,23 +1,35 @@
-name: Build and deploy
+name: Build and deploy to Github pages
 
 on:
   push:
     branches:
       - main
-      - fix/gh-pages
-    tags:
-      - "*"
+  pull_request:
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/fix/gh-pages'
+    if: github.ref != 'refs/heads/main'
     steps:
-      - name: checkout
-        uses: actions/checkout@v3
-
-      - name: build_and_deploy
-        uses: shalzz/zola-deploy-action@v0.14.1
+      - name: Checkout main
+        uses: actions/checkout@v3.0.0
+      - name: Build
+        uses: shalzz/zola-deploy-action@master
         env:
+          BUILD_DIR: docs
+          BUILD_ONLY: true
+          BUILD_FLAGS: --drafts
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build_and_deploy:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v3.0.0
+      - name: Build and deploy
+        uses: shalzz/zola-deploy-action@master
+        env:
+          BUILD_DIR: docs
           PAGES_BRANCH: gh-pages
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,6 @@ jobs:
       - name: Build and deploy
         uses: shalzz/zola-deploy-action@v0.12.0
         env:
-          BUILD_DIR: docs
+          BUILD_DIR: build
           PAGES_BRANCH: gh-pages
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@v3.0.0
       - name: Build
-        uses: shalzz/zola-deploy-action@master
+        uses: shalzz/zola-deploy-action@0.15.3
         env:
           BUILD_DIR: docs
           BUILD_ONLY: true
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@v3.0.0
       - name: Build and deploy
-        uses: shalzz/zola-deploy-action@master
+        uses: shalzz/zola-deploy-action@0.15.3
         env:
           BUILD_DIR: docs
           PAGES_BRANCH: gh-pages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Build
         uses: shalzz/zola-deploy-action@v0.12.0
         env:
-          BUILD_DIR: docs
+          BUILD_DIR: build
           BUILD_ONLY: true
           BUILD_FLAGS: --drafts
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@v3.0.0
       - name: Build
-        uses: shalzz/zola-deploy-action@v0.12.0
+        uses: shalzz/zola-deploy-action@v0.15.3
         env:
           BUILD_ONLY: true
           BUILD_FLAGS: --drafts
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@v3.0.0
       - name: Build and deploy
-        uses: shalzz/zola-deploy-action@v0.12.0
+        uses: shalzz/zola-deploy-action@v0.15.3
         env:
           PAGES_BRANCH: gh-pages
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 🌐 opensource-website
 =================
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/a509a033-951d-4d9b-a2c0-3702a8cf9107/deploy-status)](https://app.netlify.com/sites/embark-dev-opensource/deploys)
 [![Contributor Covenant](https://img.shields.io/badge/contributor%20covenant-v2.0%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 [![Embark](https://img.shields.io/badge/embark-open%20source-blueviolet.svg)](https://github.com/EmbarkStudios)
 
-Hub for Embark's open source efforts.
+Hub for [Embark's open source efforts](https://www.embark.dev/).
 
 ## About
 
-This is a website using Zola as static site generator.
+This is a website using [Zola](https://www.getzola.org/) as static site generator.
 
 Project data is provided by a small JSON file, but in the future this should be grabbed from an API.
 
@@ -24,6 +23,7 @@ zola serve
 ```
 ```sh
 # build the static content
+# default output dir `public/`
 zola build
 ```
 

--- a/build/README.md
+++ b/build/README.md
@@ -1,4 +1,0 @@
-# Keep this directory
-
-The [zola-deploy-action](https://github.com/shalzz/zola-deploy-action/blob/master/entrypoint.sh) doesn't create the build directory, hence it must exist before the build action is started.
-Build directory can be specified in `./.github/workflows/build.yml`

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,4 @@
+# Keep this directory
+
+The [zola-deploy-action](https://github.com/shalzz/zola-deploy-action/blob/master/entrypoint.sh) doesn't create the build directory, hence it must exist before the build action is started.
+Build directory can be specified in `./.github/workflows/build.yml`

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,0 @@
-[build]
-publish = "public"
-command = "zola build"
-
-[build.environment]
-ZOLA_VERSION = "0.14.1"
-
-[context.deploy-preview]
-command = "zola build --base-url $DEPLOY_PRIME_URL"


### PR DESCRIPTION
Adds the [Github action 'zola deploy action'](https://github.com/shalzz/zola-deploy-action) to push the built html output to `gh-pages`. Page will be published as a Github Page when a PR has successfully been merged.

One step on the way to reduce our dependencies on Netlify.

Part of: https://github.com/EmbarkStudios/opensource-website/issues/108
