### PR TITLE
Remove github token from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,6 @@ jobs:
         env:
           BUILD_ONLY: true
           BUILD_FLAGS: --drafts
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build_and_deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

github token does not need to be passed when `BUILD_ONLY` is set to true

### Related Issues

- https://github.com/shalzz/zola-deploy-action/pull/46
